### PR TITLE
switch include relative path to absolute path

### DIFF
--- a/src/nind_denoise/nn_common.py
+++ b/src/nind_denoise/nn_common.py
@@ -8,7 +8,7 @@ import yaml
 from enum import Enum
 import json
 import sys
-sys.path.append('..')
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 #from nind_denoise.lib import pytorch_ssim
 from nind_denoise.networks.Hul import Hulb128Net, Hul112Disc, Hulf112Disc
 from nind_denoise.networks.ThirdPartyNets import PatchGAN, UNet, MobileNetV3, deeplabv3_resnet101


### PR DESCRIPTION
I'm calling denoise_image.py from a LUA script in darktable (as an export storage), thus, this change is needed