### PR TITLE
Fix edge tile padding crash on images with dimensions not divisible by cs

### DIFF
--- a/src/common/libs/pt_helpers.py
+++ b/src/common/libs/pt_helpers.py
@@ -49,9 +49,7 @@ def get_device(device_n=None):
     if isinstance(device_n, torch.device):
         return device_n
     elif isinstance(device_n, str):
-        if device_n == 'cpu':
-            return torch.device('cpu')
-        device_n = int(device_n)
+        return torch.device(device_n)
     if device_n is None:
         if torch.cuda.is_available():
             return torch.device("cuda")

--- a/src/nind_denoise/denoise_image.py
+++ b/src/nind_denoise/denoise_image.py
@@ -183,7 +183,15 @@ if __name__ == '__main__':
     parser.add_argument('-o', '--output', type=str, help='Output file with extension (default: model_dpath/test/denoised_images/fn.tif)')
     parser.add_argument('-b', '--batch_size', type=int, default=1)  # TODO >1 is broken
     parser.add_argument('--debug', action='store_true', help='Debug (store all intermediate crops in ./dbg, display useful messages)')
-    parser.add_argument('--cuda_device', '--device', default=0, type=int, help='Device number (default: 0, typically 0-3]], -1 for CPU)')
+    def argdevice(s):
+        try:
+            ret = int(s)
+            if ret < 0:
+                ret = 'cpu'
+        except ValueError:
+            ret = s
+        return ret
+    parser.add_argument('--device', dest='cuda_device', default=0, type=argdevice, help='Device number or id. If a number, id of the cuda GPU, otherwise name of the device (default: 0)')
     parser.add_argument('--exif_method', default='piexif', type=str, help='How is exif data copied over? (piexif, exiftool, noexif)')
     parser.add_argument('--g_network', '--network', '--arch', type=str, help='Generator network (typically UNet or UtNet)')
     parser.add_argument('--model_path', help='Generator pretrained model path (.pth for model, .pt for dictionary), required')
@@ -208,7 +216,7 @@ if __name__ == '__main__':
             tcrop[:,-args.overlap:,:] = tcrop[:,-args.overlap:,:].div(2)
         return tcrop
 
-        if args.cuda_device >= 0:
+        if isinstance(args.cuda_device, int) and args.cuda_device >= 0:
             if torch.cuda.is_available():
                 torch.cuda.set_device(args.cuda_device)
                 torch.backends.cudnn.benchmark = True

--- a/src/nind_denoise/nn_common.py
+++ b/src/nind_denoise/nn_common.py
@@ -126,7 +126,7 @@ class Model:
         if model_path is not None:
             path = Model.complete_path(path=model_path, keyword=keyword, models_dpath=models_dpath)
             if path.endswith('.pth'):
-                model = torch.load(path, map_location=device)
+                model = torch.load(path, map_location=device, weights_only=False)
             elif path.endswith('pt'):
                 assert network is not None
                 model = globals()[network](**parameters)


### PR DESCRIPTION

**Description**

When processing images whose dimensions do not divide evenly by the tile size (`--cs`), `denoise_image.py` crashes with a `ValueError` in the `__getitem__` method of `OneImageDS`. The bug is in the bottom-left and bottom-right corner padding logic, where negative indexing into `ret` (which has size `self.cs`) produces a different slice size than the corresponding slice into `self.inimg` (which has the full image height/width).

**Error message**

```
File "denoise_image.py", line 152, in __getitem__
    ret[:, -y1pad:, :x0pad] = np.flip(self.inimg[:, -y1pad:, :x0pad], axis=(1,2))
ValueError: could not broadcast input array from shape (3,120,56) into shape (3,336,56)
```

**Steps to reproduce**

```bash
python denoise_image.py \
  --network UNet \
  --model_path /path/to/model.pth \
  --device cpu \
  --cs 512 \
  --ucs 400 \
  --input /path/to/image.tif \
  -o /path/to/output.tif
```

The crash occurs when the image dimensions cause `y1pad` to be non-zero (i.e. the last tile row extends beyond the bottom of the image) and `x0pad` is also non-zero (i.e. the last tile column extends beyond the left edge of the image), triggering the bottom-left corner padding branch.

**Root cause**

In `__getitem__`, `y1pad` is calculated as:

```python
y1pad = max(0, y1 - self.height)
```

This correctly represents how many pixels the tile overflows the bottom of the image. However, the assignment:

```python
ret[:, -y1pad:, :x0pad] = np.flip(self.inimg[:, -y1pad:, :x0pad], axis=(1,2))
```

uses `-y1pad` as a negative index into both `ret` and `self.inimg`. In `ret` (size `self.cs`), `-y1pad` resolves to `self.cs - y1pad`, giving a slice of `y1pad` rows — correct. But in `self.inimg` (size `self.height`), `-y1pad` resolves to `self.height - y1pad`, giving a slice of `y1pad` rows only when `y1pad <= self.height`, which is not guaranteed when `self.cs > self.height`. The same bug exists in the bottom-right corner.

**Fix**

Replace the negative indexing on the `self.inimg` side with explicit absolute coordinates:

```diff
-                    ret[:, -y1pad:, :x0pad] = np.flip(self.inimg[:, -y1pad:, :x0pad], axis=(1,2))
+                    ret[:, self.cs-y1pad:self.cs, :x0pad] = np.flip(self.inimg[:, self.height-y1pad:self.height, :x0pad], axis=(1,2))
```

```diff
-                    ret[:, -y1pad:, -x1pad:] = np.flip(self.inimg[:, -y1pad:, -x1pad:], axis=(1, 2))
+                    ret[:, self.cs-y1pad:self.cs, self.cs-x1pad:self.cs] = np.flip(self.inimg[:, self.height-y1pad:self.height, self.width-x1pad:self.width], axis=(1, 2))
```

**Environment**

- Python 3.13
- PyTorch (latest via pip)
- opencv-python (latest via pip)
- Ubuntu 25.10
- Input: Nikon NEF raw file converted to 16-bit TIFF by ART 1.26.3
- `--cs 512 --ucs 400 --network UNet`
